### PR TITLE
Bugfix: Invalid data passed to untyped property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 .phpunit.result.cache
+.vscode

--- a/src/Transform.php
+++ b/src/Transform.php
@@ -65,7 +65,7 @@ class Transform
             // We ignore untyped properties but pass data "as they are"
             $propertyType = $property->getType();
             if ($propertyType === null) {
-                $finalData[$name] = $data;
+                $finalData[$name] = $data[$name] ?? null;
                 continue;
             }
             if (! ($propertyType instanceof ReflectionNamedType)) {

--- a/tests/Examples/UntypedProperty/Substructure.php
+++ b/tests/Examples/UntypedProperty/Substructure.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest\Examples\UntypedProperty;
+
+class Substructure
+{
+    public int $num;
+    // @phpstan-ignore-next-line
+    public $anytype;
+}

--- a/tests/Examples/UntypedProperty/SubstructureCollection.php
+++ b/tests/Examples/UntypedProperty/SubstructureCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest\Examples\UntypedProperty;
+
+use Rutek\Dataclass\Collection;
+
+/** @extends Collection<Substructure> */
+class SubstructureCollection extends Collection
+{
+    public function __construct(Substructure ...$str)
+    {
+        $this->items = $str;
+    }
+}

--- a/tests/Examples/UntypedProperty/TestRoute.php
+++ b/tests/Examples/UntypedProperty/TestRoute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest\Examples\UntypedProperty;
+
+class TestRoute
+{
+    public SubstructureCollection $substructures;
+}

--- a/tests/UntypedPropertyTest.php
+++ b/tests/UntypedPropertyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest;
+
+use PHPUnit\Framework\TestCase;
+use Rutek\DataclassTest\Examples\UntypedProperty\Substructure;
+use Rutek\DataclassTest\Examples\UntypedProperty\SubstructureCollection;
+use Rutek\DataclassTest\Examples\UntypedProperty\TestRoute;
+
+use function Rutek\Dataclass\transform;
+
+class UntypedPropertyTest extends TestCase
+{
+    /** We ignore untyped properties but pass data "as they are" */
+    public function testPassesUntypedPropertyDataAsIs(): void
+    {
+        /** @var TestRoute */
+        $result = transform(TestRoute::class, [
+            'substructures' => [
+                ['num' => 1, 'anytype' => ['some' => 'data', 'val' => 123]],
+            ]
+        ]);
+        $this->assertInstanceOf(TestRoute::class, $result);
+        $this->assertInstanceOf(SubstructureCollection::class, $result->substructures);
+
+        /** @var Substructure[] */
+        $substructures = iterator_to_array($result->substructures);
+        $this->assertCount(1, $substructures);
+        $this->assertSame(1, $substructures[0]->num);
+        $this->assertSame(['some' => 'data', 'val' => 123], $substructures[0]->anytype);
+    }
+
+    /** Missing data for untyped property = NULL value */
+    public function testUntypedPropertyHasNullIfNoValueWasSpecified(): void
+    {
+        /** @var TestRoute */
+        $result = transform(TestRoute::class, [
+            'substructures' => [
+                ['num' => 1],
+            ]
+        ]);
+        $this->assertInstanceOf(TestRoute::class, $result);
+        $this->assertInstanceOf(SubstructureCollection::class, $result->substructures);
+
+        /** @var Substructure[] */
+        $substructures = iterator_to_array($result->substructures);
+        $this->assertCount(1, $substructures);
+        $this->assertSame(1, $substructures[0]->num);
+        $this->assertNull($substructures[0]->anytype);
+    }
+}


### PR DESCRIPTION
Data passed to untyped property was invalid. It contained data for entire level (data for entire object) instead of single value.

Untyped properties are always optional. Null value is set when no data has been passed for such property.