### PR TITLE
Support objects requiring some of the parameters to be filled in the constructor (part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ class MyClass
 Using different name or type for the constructor argument won't work. The goal is to support enforcing
 developer to fill in the properties.
 
+Any constructor that contains any other parameter than the properties will throw `UnsupportedException`. Parameters
+must have the same type as properties. Order is irrelevant. If it's needed, only some subset of properties can exist
+in the constructor.
+
 ### More examples
 
 Please check out [docs/ directory](docs/) for more examples.

--- a/src/UnsupportedException/ConstructorParamAndPropertyTypeMismatchException.php
+++ b/src/UnsupportedException/ConstructorParamAndPropertyTypeMismatchException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\Dataclass\UnsupportedException;
+
+use Rutek\Dataclass\UnsupportedException;
+
+class ConstructorParamAndPropertyTypeMismatchException extends UnsupportedException
+{
+    public function __construct(string $paramName)
+    {
+        parent::__construct(
+            'Constructor parameter $' . $paramName . ' has a different type than the '
+            . 'property of the class using the same name. Please make sure that types match.'
+        );
+    }
+}

--- a/src/UnsupportedException/MissingPropertyForConstructorParameterException.php
+++ b/src/UnsupportedException/MissingPropertyForConstructorParameterException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\Dataclass\UnsupportedException;
+
+use Rutek\Dataclass\UnsupportedException;
+
+class MissingPropertyForConstructorParameterException extends UnsupportedException
+{
+    public function __construct(string $paramName)
+    {
+        parent::__construct(
+            'Constructor parameter $' . $paramName . ' does not have a corresponding public '
+            . 'property of the class, so it cannot be used in constructor. Please remove it from '
+            . 'constructor or add it to public properties of the class.'
+        );
+    }
+}

--- a/tests/Examples/ObjectWithConstructor.php
+++ b/tests/Examples/ObjectWithConstructor.php
@@ -6,9 +6,6 @@ namespace Rutek\DataclassTest\Examples;
 
 class ObjectWithConstructor extends ScalarsHinting
 {
-    /**
-     * It's planned to not fill in any of properties that are required (have no default values).
-     */
     public function __construct(int $number, string $text, float $decimalNumber, bool $logicValue)
     {
         $this->number = $number;

--- a/tests/Examples/ObjectWithConstructorWithAllFields.php
+++ b/tests/Examples/ObjectWithConstructorWithAllFields.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest\Examples;
+
+class ObjectWithConstructorWithAllFields extends ScalarsHinting
+{
+    public function __construct(
+        int $number,
+        ?int $numberAllowNull,
+        string $text,
+        ?string $textAllowNull,
+        float $decimalNumber,
+        ?float $decimalNumberAllowNull,
+        bool $logicValue,
+        ?int $optionalNumber = null,
+        ?string $optionalText = null,
+        ?float $optionalDecimalNumber = null
+    ) {
+        $this->number = $number;
+        $this->numberAllowNull = $numberAllowNull;
+        $this->text = $text;
+        $this->textAllowNull = $textAllowNull;
+        $this->decimalNumber = $decimalNumber;
+        $this->decimalNumberAllowNull = $decimalNumberAllowNull;
+        $this->logicValue = $logicValue;
+        $this->optionalNumber = $optionalNumber;
+        $this->optionalText = $optionalText;
+        $this->optionalDecimalNumber = $optionalDecimalNumber;
+    }
+}

--- a/tests/Examples/ObjectWithInvalidFieldInConstructor.php
+++ b/tests/Examples/ObjectWithInvalidFieldInConstructor.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest\Examples;
+
+/**
+ * Object that does not meed library needs. It contains constructor with required parameter that is not a part
+ * of public properties of the class.
+ */
+class ObjectWithInvalidFieldInConstructor extends ScalarsHinting
+{
+    private int $someOtherField; // @phpstan-ignore-line
+
+    public function __construct(int $someOtherField)
+    {
+        $this->someOtherField = $someOtherField;
+    }
+}

--- a/tests/Examples/ObjectWithTypeMismatchInConstructor.php
+++ b/tests/Examples/ObjectWithTypeMismatchInConstructor.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rutek\DataclassTest\Examples;
+
+/** Object with constructor that has different type than property. */
+class ObjectWithTypeMismatchInConstructor extends ScalarsHinting
+{
+    public function __construct(float $number)
+    {
+        $this->number = (int)$number;
+    }
+}

--- a/tests/ObjectWithConstructorTest.php
+++ b/tests/ObjectWithConstructorTest.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace Rutek\DataclassTest;
 
 use PHPUnit\Framework\TestCase;
+use Rutek\Dataclass\UnsupportedException;
 use Rutek\DataclassTest\Examples\ObjectWithConstructor;
+use Rutek\DataclassTest\Examples\ObjectWithConstructorWithAllFields;
+use Rutek\DataclassTest\Examples\ObjectWithInvalidFieldInConstructor;
+use Rutek\DataclassTest\Examples\ObjectWithTypeMismatchInConstructor;
 
 use function Rutek\Dataclass\transform;
 
 class ObjectWithConstructorTest extends TestCase
 {
+    /** Verification of support for objects with constructor that contains some properties in it */
     public function testCanCreateObjectWithConstructor(): void
     {
         /** @var ObjectWithConstructor $obj */
@@ -39,5 +44,87 @@ class ObjectWithConstructorTest extends TestCase
         $expected->textAllowNull = 'Some third text';
 
         $this->assertEquals($expected, $obj);
+    }
+
+    /** Verification of support for objects with constructor that contains all it's properties */
+    public function testCanCreateObjectWithConstructorWithAllFields(): void
+    {
+        /** @var ObjectWithConstructorWithAllFields $obj */
+        $obj = transform(ObjectWithConstructorWithAllFields::class, [
+            'number' => 1,
+            'optionalNumber' => 2,
+            'numberAllowNull' => 3,
+            'text' => 'Some text',
+            'optionalText' => 'Some second text',
+            'textAllowNull' => 'Some third text',
+            'decimalNumber' => 1.23,
+            'optionalDecimalNumber' => 2.23,
+            'decimalNumberAllowNull' => 3.23,
+            // PHP does not support ?bool type so we don't check null here
+            'logicValue' => true,
+        ]);
+
+        $expected = new ObjectWithConstructorWithAllFields(
+            1,
+            3,
+            'Some text',
+            'Some third text',
+            1.23,
+            3.23,
+            true,
+            2,
+            'Some second text',
+            2.23
+        );
+        $this->assertEquals($expected, $obj);
+    }
+
+    /** Check if library will report that constructor is unsupported instead of throwing unexpected errors */
+    public function testReportsErrorWhenUnsupportedConstructorIsDetected(): void
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage(
+            'Constructor parameter $someOtherField does not have a corresponding public '
+            . 'property of the class, so it cannot be used in constructor. Please remove it from '
+            . 'constructor or add it to public properties of the class.'
+        );
+
+        $obj = transform(ObjectWithInvalidFieldInConstructor::class, [
+            'number' => 1,
+            'optionalNumber' => 2,
+            'numberAllowNull' => 3,
+            'text' => 'Some text',
+            'optionalText' => 'Some second text',
+            'textAllowNull' => 'Some third text',
+            'decimalNumber' => 1.23,
+            'optionalDecimalNumber' => 2.23,
+            'decimalNumberAllowNull' => 3.23,
+            // PHP does not support ?bool type so we don't check null here
+            'logicValue' => true,
+        ]);
+    }
+
+    /** Check if library performs checks for type mismatch between property and constructor arguments */
+    public function testReportsErrorWhenEncountersConstructorAndPropertyTypesMismatch(): void
+    {
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage(
+            'Constructor parameter $number has a different type than the '
+            . 'property of the class using the same name.'
+        );
+
+        $obj = transform(ObjectWithTypeMismatchInConstructor::class, [
+            'number' => 1,
+            'optionalNumber' => 2,
+            'numberAllowNull' => 3,
+            'text' => 'Some text',
+            'optionalText' => 'Some second text',
+            'textAllowNull' => 'Some third text',
+            'decimalNumber' => 1.23,
+            'optionalDecimalNumber' => 2.23,
+            'decimalNumberAllowNull' => 3.23,
+            // PHP does not support ?bool type so we don't check null here
+            'logicValue' => true,
+        ]);
     }
 }


### PR DESCRIPTION
Add more unit tests covering constructor usage.

Strictly check parameters from the constructor. They need to have the same type as corresponding properties.

Add dedicated exceptions when unsupported constructor is detected.